### PR TITLE
Implement exposing RequestTime p90, p95, p99, mean, stdev

### DIFF
--- a/aspects/counter.go
+++ b/aspects/counter.go
@@ -2,7 +2,8 @@ package ginmon
 
 import "github.com/gin-gonic/gin"
 
-// middleware
+// CounterHandler is a Gin middleware function that increments a
+// global counter on each request.
 func CounterHandler(counter *CounterAspect) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		counter.Inc()
@@ -10,6 +11,7 @@ func CounterHandler(counter *CounterAspect) gin.HandlerFunc {
 	}
 }
 
+// CounterAspect stores a counter
 type CounterAspect struct {
 	Count int
 }

--- a/aspects/counter_test.go
+++ b/aspects/counter_test.go
@@ -1,11 +1,12 @@
 package ginmon
 
 import (
-	"github.com/gin-gonic/gin"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
 )
 
 const TestMode string = "test"
@@ -14,7 +15,7 @@ const checkMark = "\u2713"
 const ballotX = "\u2717"
 
 func Test_Inc(t *testing.T) {
-	c := CounterAspect{1}
+	c := &CounterAspect{1}
 	expect := 2
 	c.Inc()
 	if assert.Equal(t, c.Count, expect, "Incrementation of counter does not work, expect %d but got %d %s",

--- a/aspects/request_time.go
+++ b/aspects/request_time.go
@@ -1,0 +1,127 @@
+package ginmon
+
+import (
+	"math"
+	"sort"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RequestTimeAspect, exported fields are used to store json fields.
+type RequestTimeAspect struct {
+	lastMinuteRequestTimes []float64
+	Min                    float64
+	Max                    float64
+	Mean                   float64
+	Stdev                  float64
+	P90                    float64
+	P95                    float64
+	P99                    float64
+	Timestamp              time.Time
+}
+
+// NewRequestTimeAspect returns a new initialized RequestTimeAspect
+// object.
+func NewRequestTimeAspect() *RequestTimeAspect {
+	rt := &RequestTimeAspect{}
+	rt.lastMinuteRequestTimes = make([]float64, 0)
+	rt.Timestamp = time.Now()
+	return rt
+}
+
+// StartTimer will call a forever loop in a goroutine to calculate
+// metrics for measurements every d ticks.
+func (rt *RequestTimeAspect) StartTimer(d time.Duration) {
+	timer := time.Tick(d)
+	go func() {
+		for {
+			<-timer
+			rt.calculate()
+		}
+	}()
+}
+
+// GetStats to fulfill aspects.Aspect interface, it returns the data
+// that will be served as JSON.
+func (rt *RequestTimeAspect) GetStats() interface{} {
+	return rt
+}
+
+// Name to fulfill aspects.Aspect interface, it will return the name
+// of the JSON object that will be served.
+func (rt *RequestTimeAspect) Name() string {
+	return "RequestTime"
+}
+
+// InRoot to fulfill aspects.Aspect interface, it will return where to
+// put the JSON object into the monitoring endpoint.
+func (rt *RequestTimeAspect) InRoot() bool {
+	return false
+}
+
+// RequestTimeHandler is a middleware function to use in Gin
+func RequestTimeHandler(rt *RequestTimeAspect) gin.HandlerFunc {
+	_rt := rt // save rt in closure
+	return func(c *gin.Context) {
+		now := time.Now()
+		c.Next()
+		took := time.Now().Sub(now)
+		_rt.add(float64(took))
+	}
+}
+
+func (rt *RequestTimeAspect) add(n float64) {
+	rt.lastMinuteRequestTimes = append(rt.lastMinuteRequestTimes, n)
+}
+
+func (rt *RequestTimeAspect) calculate() {
+	sortedSlice := rt.lastMinuteRequestTimes[:]
+	rt.lastMinuteRequestTimes = make([]float64, 0)
+	l := len(sortedSlice)
+	if l <= 1 {
+		return
+	}
+	sort.Float64s(sortedSlice)
+
+	rt.Timestamp = time.Now()
+	rt.Min = sortedSlice[0]
+	rt.Max = sortedSlice[l-1]
+	rt.Mean = mean(sortedSlice, l)
+	rt.Stdev = correctedStdev(sortedSlice, rt.Mean, l)
+	rt.P90 = p90(sortedSlice, l)
+	rt.P95 = p95(sortedSlice, l)
+	rt.P99 = p99(sortedSlice, l)
+}
+
+func mean(orderedObservations []float64, l int) float64 {
+	return percentile(orderedObservations, l, 0.5)
+}
+
+func p90(orderedObservations []float64, l int) float64 {
+	return percentile(orderedObservations, l, 0.9)
+}
+
+func p95(orderedObservations []float64, l int) float64 {
+	return percentile(orderedObservations, l, 0.95)
+}
+
+func p99(orderedObservations []float64, l int) float64 {
+	return percentile(orderedObservations, l, 0.99)
+}
+
+// percentile with argument p \in (0,1), l is the length of given orderedObservations
+// It does a simple apporximation of an ordered list of observations.
+// Formula: sortedSlice[0.95*length(sortedSlice)]
+func percentile(orderedObservations []float64, l int, p float64) float64 {
+	return orderedObservations[int(p*float64(l))]
+}
+
+func correctedStdev(observations []float64, mean float64, l int) float64 {
+	var omega float64
+	for i := 0; i < l; i++ {
+		omega += math.Pow(observations[i]-mean, 2)
+	}
+	stdev := math.Sqrt(1 / (float64(l) - 1) * omega)
+	return stdev
+}

--- a/aspects/request_time.go
+++ b/aspects/request_time.go
@@ -8,17 +8,18 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// RequestTimeAspect, exported fields are used to store json fields.
+// RequestTimeAspect, exported fields are used to store json
+// fields. All fields are measured in nanoseconds.
 type RequestTimeAspect struct {
 	lastMinuteRequestTimes []float64
-	Min                    float64
-	Max                    float64
-	Mean                   float64
-	Stdev                  float64
-	P90                    float64
-	P95                    float64
-	P99                    float64
-	Timestamp              time.Time
+	Min                    float64   `json:"min"`
+	Max                    float64   `json:"max"`
+	Mean                   float64   `json:"mean"`
+	Stdev                  float64   `json:"stdev"`
+	P90                    float64   `json:"p90"`
+	P95                    float64   `json:"p95"`
+	P99                    float64   `json:"p99"`
+	Timestamp              time.Time `json:"timestamp"`
 }
 
 // NewRequestTimeAspect returns a new initialized RequestTimeAspect

--- a/example/main.go
+++ b/example/main.go
@@ -29,7 +29,13 @@ func main() {
 
 	// each request to all handlers like below will increment the Counter
 	router.GET("/", func(ctx *gin.Context) {
-		ctx.JSON(http.StatusOK, gin.H{"title": "Counter - Hello World - Loook at http://localhost:9000/Counter"})
+		ctx.JSON(http.StatusOK, gin.H{
+			"Counter": map[string]string{
+				"msg": "Request Counter - Loook at http://localhost:9000/Counter",
+				"cmd": "curl http://localhost:9000/Counter; for i in {1..20}; do curl localhost:8080/; done; curl http://localhost:9000/Counter"},
+			"RequestTime": map[string]string{
+				"msg": "RequestTime is registered at http://localhost:9000/RequestTime and will return data after 5 seconds.",
+				"cmd": "for j in {0..100}; do for i in {1..20}; do curl localhost:8080/ ; done; sleep 0.5; curl localhost:9000/RequestTime ; done"}})
 	})
 
 	log.Fatal(router.Run(":8080"))

--- a/example/main.go
+++ b/example/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"log"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/zalando/gin-gomonitor"
@@ -10,11 +12,16 @@ import (
 )
 
 func main() {
+	requestAspect := ginmon.NewRequestTimeAspect()
+	requestAspect.StartTimer(5 * time.Second)
+
 	counterAspect := &ginmon.CounterAspect{0}
-	asps := []aspects.Aspect{counterAspect}
+	asps := []aspects.Aspect{counterAspect, requestAspect}
 	router := gin.New()
 	// curl http://localhost:9000/Counter
 	router.Use(ginmon.CounterHandler(counterAspect))
+	// curl http://localhost:9000/RequestTime
+	router.Use(ginmon.RequestTimeHandler(requestAspect))
 	// curl http://localhost:9000/
 	router.Use(gomonitor.Metrics(9000, asps))
 	// last middleware
@@ -25,6 +32,5 @@ func main() {
 		ctx.JSON(http.StatusOK, gin.H{"title": "Counter - Hello World - Loook at http://localhost:9000/Counter"})
 	})
 
-	//..
-	router.Run(":8080")
+	log.Fatal(router.Run(":8080"))
 }


### PR DESCRIPTION
Here is the json object

  "RequestTime": {
    "Min": 11675,
    "Max": 170701,
    "Mean": 16409,
    "Stdev": 16925.31859272991,
    "P90": 25546,
    "P95": 51503,
    "P99": 82202,
    "Timestamp": "2016-12-20T15:43:48.89528195+01:00"
  }

I will change it to have lowercase json keys as it should be.