### PR TITLE
implement status code counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,22 @@ When it comes to choosing a Go framework, there's a lot of confusion about what 
 
 We've liked using Gin for its speed, accessibility, and usefulness in developing microservice architectures. In creating Gin-Gomonitor, we wanted to take fuller advantage of [Gin](https://github.com/gin-gonic/gin)'s capabilities and help other devs do likewise.
 
+We implemented the following custom
+[Aspects](https://github.com/zalando/gin-gomonitor/tree/master/aspects):
+
+CounterAspect implements a counter for request per time.Duration,
+counting the sum of all and for each path independent counters.
+
+RequestTimeAspect implements the measurement of request times
+including values for min, max, mean, stdev, p90, p95, p99.
+
+See also our [full example](https://github.com/zalando/gin-gomonitor/blob/master/example/main.go).
+
 #### How Go-Monitor Is Different from Other Metric Libraries
 
-Go-Monitor is easily extendable, does not need type casts to create JSON, and has useful metrics already defined. It exposes metrics as JSON to a metrics endpoint using a different TCP port.
+Go-Monitor is easily extendable, does not need type casts to create
+JSON, and has useful metrics already defined. It exposes metrics as
+JSON to a metrics endpoint using a different TCP port.
 
 ## Requirements
 
@@ -63,7 +76,9 @@ Next, initialize the CounterAspect defined by Gin-Gomonitor and your own CustomA
 ```go
     router := gin.New()
 
-    counterAspect := &ginmon.CounterAspect{0}
+    counterAspect := ginmon.NewCounterAspect()
+    counterAspect.StartTimer(1 * time.Minute)
+
     anotherAspect := &CustomAspect{3}
     asps := []aspects.Aspect{counterAspect, anotherAspect}
     router.Use(ginmon.CounterHandler(counterAspect))
@@ -81,22 +96,32 @@ The page's counter metric will increment if you hit the page:
 
     % curl http://localhost:9000/Counter
     {
-      "Counter": 0
+        "Counter": {
+            "request_sum_per_minute": 0,
+            "requests_per_minute": {},
+            "request_codes_per_minute": {}
+        }
     }
-    % curl http://localhost:8080/
-    {"title":"Counter - Hello World - Loook at http://localhost:9000/Counter"}
-    % curl http://localhost:8080/
-    {"title":"Counter - Hello World - Loook at http://localhost:9000/Counter"}
-    % curl http://localhost:9000/Counter
+    % for i in {1..20}; do curl localhost:8080/ &>/dev/null ; curl localhost:8080/foo &>/dev/null ; done; sleep 1; curl http://localhost:9000/Counter
     {
-      "Counter": 2
+        "Counter": {
+            "request_sum_per_minute": 40,
+            "requests_per_minute": {
+                "/": 20,
+                "/foo": 20
+            },
+            "request_codes_per_minute": {
+                "200": 20,
+                "404": 20
+            }
+        }
     }
 
 The page custom metric will show three as defined:
 
-    % curl http://localhost:9000/Counter
+    % curl http://localhost:9000/Custom
     {
-      "Counter": 0
+      "Custom: 3
     }
 
 The regular metrics from go-monitor exposes Go process and build information:

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The page's counter metric will increment if you hit the page:
             "request_codes_per_minute": {}
         }
     }
-    % for i in {1..20}; do curl localhost:8080/ &>/dev/null ; curl localhost:8080/foo &>/dev/null ; done; sleep 1; curl http://localhost:9000/Counter
+    % for i in {1..20}; do curl localhost:8080/ &>/dev/null ; curl localhost:8080/foo &>/dev/null ; done; sleep 3; curl http://localhost:9000/Counter
     {
         "Counter": {
             "request_sum_per_minute": 40,

--- a/aspects/counter.go
+++ b/aspects/counter.go
@@ -53,16 +53,16 @@ func (ca *CounterAspect) StartTimer(d time.Duration) {
 	timer := time.Tick(d)
 	go func() {
 		for {
-			tup := <-ca.inc
-			ca.internalRequestsSum++
-			ca.internalRequests[tup.path]++
-			ca.internalRequestCodes[tup.code]++
-		}
-	}()
-	go func() {
-		for {
-			<-timer
-			ca.reset()
+			select {
+			case tup := <-ca.inc:
+
+				ca.internalRequestsSum++
+				ca.internalRequests[tup.path]++
+				ca.internalRequestCodes[tup.code]++
+
+			case <-timer:
+				ca.reset()
+			}
 		}
 	}()
 }

--- a/aspects/counter.go
+++ b/aspects/counter.go
@@ -1,33 +1,91 @@
 package ginmon
 
-import "github.com/gin-gonic/gin"
+import (
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
 
 // CounterHandler is a Gin middleware function that increments a
 // global counter on each request.
-func CounterHandler(counter *CounterAspect) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		counter.Inc()
-		c.Next()
+func CounterHandler(ca *CounterAspect) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		ca.Inc(ctx)
+		ctx.Next()
+		ca.IncCodes(ctx)
 	}
 }
 
 // CounterAspect stores a counter
 type CounterAspect struct {
-	Count int
+	internalRequestsSum  int
+	internalRequests     map[string]int
+	internalRequestCodes map[int]int
+	RequestsSum          int            `json:"request_sum_per_minute"`
+	Requests             map[string]int `json:"requests_per_minute"`
+	RequestCodes         map[int]int    `json:"request_codes_per_minute"`
 }
 
-func (a *CounterAspect) Inc() {
-	a.Count++
+// NewCounterAspect returns a new initialized CounterAspect object.
+func NewCounterAspect() *CounterAspect {
+	ca := &CounterAspect{}
+	ca.internalRequestsSum = 0
+	ca.internalRequests = make(map[string]int, 0)
+	ca.internalRequestCodes = make(map[int]int, 0)
+	return ca
 }
 
-func (a *CounterAspect) GetStats() interface{} {
-	return a.Count
+// StartTimer will call a forever loop in a goroutine to calculate
+// metrics for measurements every d ticks. The parameter of this
+// function should normally be 1 * time.Minute, if not it will expose
+// unintuive JSON keys (requests_per_minute and
+// request_sum_per_minute).
+func (ca *CounterAspect) StartTimer(d time.Duration) {
+	timer := time.Tick(d)
+	go func() {
+		for {
+			<-timer
+			ca.reset()
+		}
+	}()
 }
 
-func (a *CounterAspect) Name() string {
+// Inc will increment internal counters that are not exposed. Counters
+// will be exposed if you call reset().
+func (ca *CounterAspect) Inc(ctx *gin.Context) {
+	ca.internalRequestsSum++
+	ca.internalRequests[ctx.Request.URL.Path]++
+}
+
+// IncCodes will increment internal counters that are not
+// exposed. Counters will be exposed if you call reset().
+func (ca *CounterAspect) IncCodes(ctx *gin.Context) {
+	ca.internalRequestCodes[ctx.Writer.Status()]++
+}
+
+// GetStats to fulfill aspects.Aspect interface, it returns the data
+// that will be served as JSON.
+func (ca *CounterAspect) GetStats() interface{} {
+	return *ca
+}
+
+// Name to fulfill aspects.Aspect interface, it will return the name
+// of the JSON object that will be served.
+func (ca *CounterAspect) Name() string {
 	return "Counter"
 }
 
-func (a *CounterAspect) InRoot() bool {
+// InRoot to fulfill aspects.Aspect interface, it will return where to
+// put the JSON object into the monitoring endpoint.
+func (ca *CounterAspect) InRoot() bool {
 	return false
+}
+
+func (ca *CounterAspect) reset() {
+	ca.RequestsSum = ca.internalRequestsSum
+	ca.Requests = ca.internalRequests
+	ca.RequestCodes = ca.internalRequestCodes
+	ca.internalRequestsSum = 0
+	ca.internalRequests = make(map[string]int, ca.RequestsSum)
+	ca.internalRequestCodes = make(map[int]int, len(ca.RequestCodes))
 }

--- a/aspects/counter_test.go
+++ b/aspects/counter_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -29,8 +30,12 @@ func internalGinCtx() *gin.Context {
 
 func Test_Inc(t *testing.T) {
 	ca := NewCounterAspect()
+	ca.StartTimer(1 * time.Second)
 	expect := 1
-	ca.Inc(internalGinCtx())
+	ca.inc <- tuple{
+		path: testpath,
+		code: 404,
+	}
 	ca.reset()
 	if assert.Equal(t, ca.RequestsSum, expect, "Incrementation of counter does not work, expect %d but got %d %s",
 		expect, ca.RequestsSum, ballotX) {
@@ -41,6 +46,7 @@ func Test_Inc(t *testing.T) {
 
 func Test_GetStats(t *testing.T) {
 	ca := NewCounterAspect()
+	ca.StartTimer(1 * time.Second)
 	if assert.NotNil(t, ca.GetStats(), "Return of Getstats() should not be nil") {
 		t.Logf("Should be an interface %s", checkMark)
 	}
@@ -53,7 +59,10 @@ func Test_GetStats(t *testing.T) {
 			expect, newCa.RequestsSum, checkMark)
 	}
 
-	ca.Inc(internalGinCtx())
+	ca.inc <- tuple{
+		path: testpath,
+		code: 404,
+	}
 	if assert.Equal(t, newCa.RequestsSum, expect, "Return of Getstats() does not work, expect %d but got %d %s",
 		expect, newCa.RequestsSum, ballotX) {
 		t.Logf("Return of Getstats() works, expect %d and got %d %s",
@@ -104,8 +113,12 @@ func Test_CounterHandler(t *testing.T) {
 	gin.SetMode(TestMode)
 	router := gin.New()
 	ca := NewCounterAspect()
+	ca.StartTimer(1 * time.Second)
 	expect := 1
-	ca.Inc(internalGinCtx())
+	ca.inc <- tuple{
+		path: testpath,
+		code: 404,
+	}
 	ca.reset()
 
 	router.Use(CounterHandler(ca))

--- a/aspects/counter_test.go
+++ b/aspects/counter_test.go
@@ -37,7 +37,7 @@ func Test_Inc(t *testing.T) {
 		code: 404,
 	}
 	ca.reset()
-	if assert.Equal(t, ca.RequestsSum, expect, "Incrementation of counter does not work, expect %d but got %d %s",
+	if assert.Equal(t, expect, ca.RequestsSum, "Incrementation of counter does not work, expect %d but got %d %s",
 		expect, ca.RequestsSum, ballotX) {
 		t.Logf("Incrementation of counter works, expect %d and git %d %s",
 			expect, ca.RequestsSum, checkMark)
@@ -53,7 +53,7 @@ func Test_GetStats(t *testing.T) {
 
 	newCa := ca.GetStats().(CounterAspect)
 	expect := 0
-	if assert.Equal(t, newCa.RequestsSum, expect, "Return of Getstats() does not work, expect %d but got %d %s",
+	if assert.Equal(t, expect, newCa.RequestsSum, "Return of Getstats() does not work, expect %d but got %d %s",
 		expect, newCa.RequestsSum, ballotX) {
 		t.Logf("Return of Getstats() works, expect %d and got %d %s",
 			expect, newCa.RequestsSum, checkMark)
@@ -63,12 +63,12 @@ func Test_GetStats(t *testing.T) {
 		path: testpath,
 		code: 404,
 	}
-	if assert.Equal(t, newCa.RequestsSum, expect, "Return of Getstats() does not work, expect %d but got %d %s",
+	if assert.Equal(t, expect, newCa.RequestsSum, "Return of Getstats() does not work, expect %d but got %d %s",
 		expect, newCa.RequestsSum, ballotX) {
 		t.Logf("Return of Getstats() works, expect %d and got %d %s",
 			expect, newCa.RequestsSum, checkMark)
 	}
-	if assert.Equal(t, newCa.Requests[testpath], expect, "Return of Getstats() does not work, expect %d but got %d %s",
+	if assert.Equal(t, expect, newCa.Requests[testpath], "Return of Getstats() does not work, expect %d but got %d %s",
 		expect, newCa.Requests[testpath], ballotX) {
 		t.Logf("Return of Getstats() works, expect %d and got %d %s",
 			expect, newCa.Requests[testpath], checkMark)
@@ -77,12 +77,12 @@ func Test_GetStats(t *testing.T) {
 	ca.reset()
 	newCa = ca.GetStats().(CounterAspect)
 	expect = 1
-	if assert.Equal(t, newCa.RequestsSum, expect, "Return of Getstats() does not work, expect %d but got %d %s",
+	if assert.Equal(t, expect, newCa.RequestsSum, "Return of Getstats() does not work, expect %d but got %d %s",
 		expect, newCa.RequestsSum, ballotX) {
 		t.Logf("Return of Getstats() works, expect %d and got %d %s",
 			expect, newCa.RequestsSum, checkMark)
 	}
-	if assert.Equal(t, newCa.Requests[testpath], expect, "Return of Getstats() does not work, expect %d but got %d %s",
+	if assert.Equal(t, expect, newCa.Requests[testpath], "Return of Getstats() does not work, expect %d but got %d %s",
 		expect, newCa.Requests[testpath], ballotX) {
 		t.Logf("Return of Getstats() works, expect %d and got %d %s",
 			expect, newCa.Requests[testpath], checkMark)
@@ -92,7 +92,7 @@ func Test_GetStats(t *testing.T) {
 func Test_Name(t *testing.T) {
 	ca := NewCounterAspect()
 	expect := "Counter"
-	if assert.Equal(t, ca.Name(), expect, "Return of counter name does not work, expect %s but got %s %s",
+	if assert.Equal(t, expect, ca.Name(), "Return of counter name does not work, expect %s but got %s %s",
 		expect, ca.Name(), ballotX) {
 		t.Logf("Return of counter name works, expect %s and got %s %s",
 			expect, ca.Name(), checkMark)
@@ -102,7 +102,7 @@ func Test_Name(t *testing.T) {
 func Test_InRoot(t *testing.T) {
 	ca := NewCounterAspect()
 	expect := false
-	if assert.Equal(t, ca.InRoot(), expect, "Expect %v but got %v %s",
+	if assert.Equal(t, expect, ca.InRoot(), "Expect %v but got %v %s",
 		expect, ca.InRoot(), ballotX) {
 		t.Logf("Expect %v and got %v %s",
 			expect, ca.InRoot(), checkMark)
@@ -123,7 +123,7 @@ func Test_CounterHandler(t *testing.T) {
 
 	router.Use(CounterHandler(ca))
 	tryRequest(router, "GET", "/")
-	if assert.Equal(t, ca.RequestsSum, expect, "Incrementation of counter does not work, expect %d but got %d %s", expect, ca.RequestsSum, ballotX) {
+	if assert.Equal(t, expect, ca.RequestsSum, "Incrementation of counter does not work, expect %d but got %d %s", expect, ca.RequestsSum, ballotX) {
 		t.Logf("CounterHandler works, expect %d and got %d %s", expect, ca.RequestsSum, checkMark)
 	}
 }

--- a/aspects/counter_test.go
+++ b/aspects/counter_test.go
@@ -46,7 +46,7 @@ func Test_Inc(t *testing.T) {
 
 func Test_GetStats(t *testing.T) {
 	ca := NewCounterAspect()
-	ca.StartTimer(1 * time.Second)
+	ca.StartTimer(10 * time.Second)
 	if assert.NotNil(t, ca.GetStats(), "Return of Getstats() should not be nil") {
 		t.Logf("Should be an interface %s", checkMark)
 	}

--- a/aspects/counter_test.go
+++ b/aspects/counter_test.go
@@ -3,6 +3,7 @@ package ginmon
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -14,52 +15,103 @@ const TestMode string = "test"
 const checkMark = "\u2713"
 const ballotX = "\u2717"
 
+const testpath = "/foo/bar"
+
+func internalGinCtx() *gin.Context {
+	return &gin.Context{
+		Request: &http.Request{
+			URL: &url.URL{
+				Path: testpath,
+			},
+		},
+	}
+}
+
 func Test_Inc(t *testing.T) {
-	c := &CounterAspect{1}
-	expect := 2
-	c.Inc()
-	if assert.Equal(t, c.Count, expect, "Incrementation of counter does not work, expect %d but got %d %s",
-		expect, c.Count, ballotX) {
+	ca := NewCounterAspect()
+	expect := 1
+	ca.Inc(internalGinCtx())
+	ca.reset()
+	if assert.Equal(t, ca.RequestsSum, expect, "Incrementation of counter does not work, expect %d but got %d %s",
+		expect, ca.RequestsSum, ballotX) {
 		t.Logf("Incrementation of counter works, expect %d and git %d %s",
-			expect, c.Count, checkMark)
+			expect, ca.RequestsSum, checkMark)
 	}
 }
 
 func Test_GetStats(t *testing.T) {
-	c := CounterAspect{1}
-	if assert.NotNil(t, c.GetStats(), "Return of counter getstats should not be nil") {
+	ca := NewCounterAspect()
+	if assert.NotNil(t, ca.GetStats(), "Return of Getstats() should not be nil") {
 		t.Logf("Should be an interface %s", checkMark)
+	}
+
+	newCa := ca.GetStats().(CounterAspect)
+	expect := 0
+	if assert.Equal(t, newCa.RequestsSum, expect, "Return of Getstats() does not work, expect %d but got %d %s",
+		expect, newCa.RequestsSum, ballotX) {
+		t.Logf("Return of Getstats() works, expect %d and got %d %s",
+			expect, newCa.RequestsSum, checkMark)
+	}
+
+	ca.Inc(internalGinCtx())
+	if assert.Equal(t, newCa.RequestsSum, expect, "Return of Getstats() does not work, expect %d but got %d %s",
+		expect, newCa.RequestsSum, ballotX) {
+		t.Logf("Return of Getstats() works, expect %d and got %d %s",
+			expect, newCa.RequestsSum, checkMark)
+	}
+	if assert.Equal(t, newCa.Requests[testpath], expect, "Return of Getstats() does not work, expect %d but got %d %s",
+		expect, newCa.Requests[testpath], ballotX) {
+		t.Logf("Return of Getstats() works, expect %d and got %d %s",
+			expect, newCa.Requests[testpath], checkMark)
+	}
+
+	ca.reset()
+	newCa = ca.GetStats().(CounterAspect)
+	expect = 1
+	if assert.Equal(t, newCa.RequestsSum, expect, "Return of Getstats() does not work, expect %d but got %d %s",
+		expect, newCa.RequestsSum, ballotX) {
+		t.Logf("Return of Getstats() works, expect %d and got %d %s",
+			expect, newCa.RequestsSum, checkMark)
+	}
+	if assert.Equal(t, newCa.Requests[testpath], expect, "Return of Getstats() does not work, expect %d but got %d %s",
+		expect, newCa.Requests[testpath], ballotX) {
+		t.Logf("Return of Getstats() works, expect %d and got %d %s",
+			expect, newCa.Requests[testpath], checkMark)
 	}
 }
 
 func Test_Name(t *testing.T) {
-	c := CounterAspect{1}
+	ca := NewCounterAspect()
 	expect := "Counter"
-	if assert.Equal(t, c.Name(), expect, "Return of counter name does not work, expect %s but got %s %s",
-		expect, c.Name(), ballotX) {
+	if assert.Equal(t, ca.Name(), expect, "Return of counter name does not work, expect %s but got %s %s",
+		expect, ca.Name(), ballotX) {
 		t.Logf("Return of counter name works, expect %s and got %s %s",
-			expect, c.Name(), checkMark)
+			expect, ca.Name(), checkMark)
 	}
 }
 
 func Test_InRoot(t *testing.T) {
-	c := CounterAspect{1}
+	ca := NewCounterAspect()
 	expect := false
-	if assert.Equal(t, c.InRoot(), expect, "Expect %v but got %v %s",
-		expect, c.InRoot(), ballotX) {
+	if assert.Equal(t, ca.InRoot(), expect, "Expect %v but got %v %s",
+		expect, ca.InRoot(), ballotX) {
 		t.Logf("Expect %v and got %v %s",
-			expect, c.InRoot(), checkMark)
+			expect, ca.InRoot(), checkMark)
 	}
 }
 
 func Test_CounterHandler(t *testing.T) {
 	gin.SetMode(TestMode)
 	router := gin.New()
-	cnt := &CounterAspect{1}
-	router.Use(CounterHandler(cnt))
+	ca := NewCounterAspect()
+	expect := 1
+	ca.Inc(internalGinCtx())
+	ca.reset()
+
+	router.Use(CounterHandler(ca))
 	tryRequest(router, "GET", "/")
-	if assert.Equal(t, cnt.Count, 2, "Incrementation of counter does not work, expect %d but got %d %s", 2, cnt.Count, ballotX) {
-		t.Logf("CounterHandler works, expect %d and got %d %s", 2, cnt.Count, checkMark)
+	if assert.Equal(t, ca.RequestsSum, expect, "Incrementation of counter does not work, expect %d but got %d %s", expect, ca.RequestsSum, ballotX) {
+		t.Logf("CounterHandler works, expect %d and got %d %s", expect, ca.RequestsSum, checkMark)
 	}
 }
 

--- a/example/main.go
+++ b/example/main.go
@@ -15,8 +15,11 @@ func main() {
 	requestAspect := ginmon.NewRequestTimeAspect()
 	requestAspect.StartTimer(5 * time.Second)
 
-	counterAspect := &ginmon.CounterAspect{0}
+	counterAspect := ginmon.NewCounterAspect()
+	counterAspect.StartTimer(1 * time.Second)
+
 	asps := []aspects.Aspect{counterAspect, requestAspect}
+
 	router := gin.New()
 	// curl http://localhost:9000/Counter
 	router.Use(ginmon.CounterHandler(counterAspect))
@@ -32,7 +35,7 @@ func main() {
 		ctx.JSON(http.StatusOK, gin.H{
 			"Counter": map[string]string{
 				"msg": "Request Counter - Loook at http://localhost:9000/Counter",
-				"cmd": "curl http://localhost:9000/Counter; for i in {1..20}; do curl localhost:8080/; done; curl http://localhost:9000/Counter"},
+				"cmd": "curl http://localhost:9000/Counter ; for i in {1..20}; do curl localhost:8080/ &>/dev/null ; curl localhost:8080/foo &>/dev/null ; done; sleep 1; curl http://localhost:9000/Counter"},
 			"RequestTime": map[string]string{
 				"msg": "RequestTime is registered at http://localhost:9000/RequestTime and will return data after 5 seconds.",
 				"cmd": "for j in {0..100}; do for i in {1..20}; do curl localhost:8080/ ; done; sleep 0.5; curl localhost:9000/RequestTime ; done"}})

--- a/example/main.go
+++ b/example/main.go
@@ -16,7 +16,7 @@ func main() {
 	requestAspect.StartTimer(5 * time.Second)
 
 	counterAspect := ginmon.NewCounterAspect()
-	counterAspect.StartTimer(1 * time.Second)
+	counterAspect.StartTimer(3 * time.Second)
 
 	asps := []aspects.Aspect{counterAspect, requestAspect}
 
@@ -35,7 +35,7 @@ func main() {
 		ctx.JSON(http.StatusOK, gin.H{
 			"Counter": map[string]string{
 				"msg": "Request Counter - Loook at http://localhost:9000/Counter",
-				"cmd": "curl http://localhost:9000/Counter ; for i in {1..20}; do curl localhost:8080/ &>/dev/null ; curl localhost:8080/foo &>/dev/null ; done; sleep 1; curl http://localhost:9000/Counter"},
+				"cmd": "curl http://localhost:9000/Counter ; for i in {1..20}; do curl localhost:8080/ &>/dev/null ; curl localhost:8080/foo &>/dev/null ; done; sleep 3; curl http://localhost:9000/Counter"},
 			"RequestTime": map[string]string{
 				"msg": "RequestTime is registered at http://localhost:9000/RequestTime and will return data after 5 seconds.",
 				"cmd": "for j in {0..100}; do for i in {1..20}; do curl localhost:8080/ ; done; sleep 0.5; curl localhost:9000/RequestTime ; done"}})


### PR DESCRIPTION
This implements #8 .
There are two different type of counters we expose:

1. Requests per minute counters for called paths and the sum of all calls
2. Status codes counters can be used to understand the global healthiness of your application. We get statusCodes after all other middlewares and Handlers are called. 